### PR TITLE
Fix testcases, change behaviour a bit.

### DIFF
--- a/src/main/java/seedu/address/MainApp.java
+++ b/src/main/java/seedu/address/MainApp.java
@@ -66,6 +66,7 @@ public class MainApp extends Application {
         ui = new UiManager(logic, config, userPrefs);
 
         initEventsCenter();
+        
     }
 
     private String getApplicationParameter(String parameterName){

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -68,4 +68,5 @@ public interface Model {
     
     /** Sets the system time. */
     void setSystemTime(AgendaTimeRangeChangedEvent atrce);
+
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -1,6 +1,5 @@
 package seedu.address.model;
 
-import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashSet;
@@ -46,7 +45,7 @@ public class ModelManager extends ComponentManager implements Model {
     private Expression previousExpression;
     private TaskDate previousDate;
 
-    // @@author A0135782Y
+    //@@author A0135782Y
     /**
      * Initializes a ModelManager with the given TaskList TaskList and its
      * variables should not be null
@@ -64,16 +63,17 @@ public class ModelManager extends ComponentManager implements Model {
         if (RecurringTaskManager.getInstance().updateAnyRecurringTasks()) {
             indicateTaskListChanged();
         }
-        previousExpression = new PredicateExpression(new InitialQualifier());
         previousDate = new TaskDate(new Date(System.currentTimeMillis()));
+        previousExpression = new PredicateExpression(new InitialQualifier());
+        
     }
 
-    // @@author
+    //@@author
     public ModelManager() {
         this(new TaskMaster(), new UserPrefs());
     }
 
-    // @@author A0135782Y
+    //@@author A0135782Y
     public ModelManager(ReadOnlyTaskMaster initialData, UserPrefs userPrefs) {
         taskMaster = new TaskMaster(initialData);
         tasks = taskMaster.getTasks();
@@ -83,11 +83,10 @@ public class ModelManager extends ComponentManager implements Model {
         if (RecurringTaskManager.getInstance().updateAnyRecurringTasks()) {
             indicateTaskListChanged();
         }
-        previousExpression = new PredicateExpression(new InitialQualifier());
         previousDate = new TaskDate(new Date(System.currentTimeMillis()));
-        showTaskToday();
+        previousExpression = new PredicateExpression(new InitialQualifier());
     }
-    // @@author
+    //@@author
 
     @Override
     public void resetData(ReadOnlyTaskMaster newData) {
@@ -111,7 +110,7 @@ public class ModelManager extends ComponentManager implements Model {
         indicateTaskListChanged();
     }
 
-    // @@author A0147995H
+    //@@author A0147995H
     @Override
     public synchronized void editTask(Task target, Name name, UniqueTagList tags, TaskDate startDate, TaskDate endDate,
             RecurringType recurringType) throws TaskNotFoundException, TimeslotOverlapException {
@@ -119,9 +118,9 @@ public class ModelManager extends ComponentManager implements Model {
         indicateTaskListChanged();
         updateFilteredTaskList(previousExpression);
     }
-    // @@author
+    //@@author
 
-    // @@author A0135782Y
+    //@@author A0135782Y
     @Override
     public synchronized void addTask(Task task) throws UniqueTaskList.DuplicateTaskException, TimeslotOverlapException {
         taskMaster.addTask(task);
@@ -130,7 +129,7 @@ public class ModelManager extends ComponentManager implements Model {
         indicateTaskListChanged();
     }
 
-    // @@author A0147967J
+    //@@author A0147967J
     @Override
     public synchronized void archiveTask(TaskOccurrence target) throws TaskNotFoundException {
         taskMaster.archiveTask(target);
@@ -143,7 +142,7 @@ public class ModelManager extends ComponentManager implements Model {
     public void changeDirectory(String filePath) {
         raise(new FilePathChangeEvent(filePath));
     }
-    // @@author
+    //@@author
 
     // =========== Filtered Task List Accessory ===============================================================
 
@@ -170,9 +169,22 @@ public class ModelManager extends ComponentManager implements Model {
                 new PredicateExpression(new FindQualifier(keywords, tags, startDate, endDate, deadline)));
     }
     
+    //@@A0147967J
     @Override
     public void updateFilteredTaskList(Expression expression) {
+        previousExpression  = expression;
         filteredTaskComponents.setPredicate(expression::satisfies);
+    }
+    
+
+    @Override
+    public Expression getPreviousExpression() {
+        return previousExpression;
+    }
+    
+    @Override 
+    public TaskDate getPreviousDate(){
+        return previousDate;
     }
     
     @Override
@@ -182,12 +194,7 @@ public class ModelManager extends ComponentManager implements Model {
         updateFilteredTaskList(new HashSet<String>(), new HashSet<String>(),
                 DateFormatterUtil.getStartOfDay(atrce.getInputDate().getDate()), DateFormatterUtil.getEndOfDay(atrce.getInputDate().getDate()), null);
     }
-    
-    public void showTaskToday() {
-        Date date = DateFormatterUtil.localDateToDate(LocalDate.now());
-        updateFilteredTaskList(new HashSet<String>(), new HashSet<String>(), 
-                DateFormatterUtil.getStartOfDay(date), DateFormatterUtil.getEndOfDay(date), null);
-    }
+    //@@author
 
     // ========== Inner classes/interfaces used for filtering ==================================================
 
@@ -216,7 +223,16 @@ public class ModelManager extends ComponentManager implements Model {
 
     }
 
-    // @@author A0147967J
+    //@@author A0147967J
+    private class InitialQualifier implements Qualifier {
+
+        @Override
+        public boolean run(TaskOccurrence task) {
+            return true;
+        }
+        
+    }
+    
     private class TypeQualifier implements Qualifier {
         private TaskType typeKeyWords;
 
@@ -231,20 +247,7 @@ public class ModelManager extends ComponentManager implements Model {
 
     }
     
-    private class InitialQualifier implements Qualifier {
-
-        InitialQualifier() {
-        }
-
-        @Override
-        public boolean run(TaskOccurrence task) {
-            return true;
-        }
-
-    }
-    // @@author
-
-    // @@author A0135782Y
+    //@@author A0135782Y
     private class ArchiveQualifier implements Qualifier {
         private boolean isArchived;
 
@@ -258,9 +261,9 @@ public class ModelManager extends ComponentManager implements Model {
         }
 
     }
-    // @@author
+    //@@author
 
-    // @@author A0147995H
+    //@@author A0147995H
     private class NameQualifier implements Qualifier {
         private Set<String> nameKeyWords;
 
@@ -419,16 +422,6 @@ public class ModelManager extends ComponentManager implements Model {
         }
 
     }
-    // @@author
+    //@@author
 
-    @Override
-    public Expression getPreviousExpression() {
-        // TODO Auto-generated method stub
-        return previousExpression;
-    }
-    
-    @Override 
-    public TaskDate getPreviousDate(){
-        return previousDate;
-    }
 }

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -220,6 +220,10 @@ public class MainWindow extends UiPart {
     public void releaseResources() {
         browserPanel.freeResources();
     }
+
+    public void switchToInitialTab() {
+        logic.execute("find from 12am to tomorrow 12am");
+    }
     
     
 }

--- a/src/main/java/seedu/address/ui/NavbarPanel.java
+++ b/src/main/java/seedu/address/ui/NavbarPanel.java
@@ -4,7 +4,6 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Locale;
 import java.util.logging.Logger;
-import javafx.application.Platform;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
@@ -19,7 +18,6 @@ import seedu.address.commons.core.LogsCenter;
 import seedu.address.commons.events.ui.NavigationSelectionChangedEvent;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.ListCommand;
-import seedu.address.logic.commands.ViewCommand;
 
 public class NavbarPanel extends UiPart {
 
@@ -102,7 +100,7 @@ public class NavbarPanel extends UiPart {
         switch (navigation) {
 
         case NAVBAR_TODAY:
-            command = ViewCommand.COMMAND_WORD + " by today";
+            command = FindCommand.COMMAND_WORD + " from 12am to tomorrow 12am";
             return command;
         case NAVBAR_DEADLINES:
             day = new Date(System.currentTimeMillis() + 24 * 60 * 60 * 1000);

--- a/src/main/java/seedu/address/ui/UiManager.java
+++ b/src/main/java/seedu/address/ui/UiManager.java
@@ -54,6 +54,7 @@ public class UiManager extends ComponentManager implements Ui {
             mainWindow = MainWindow.load(primaryStage, config, prefs, logic);
             mainWindow.show(); //This should be called before creating other UI parts
             mainWindow.fillInnerParts();
+            mainWindow.switchToInitialTab();
         } catch (Throwable e) {
             logger.severe(StringUtil.getDetails(e));
             showFatalErrorDialogAndShutdown("Fatal error during initializing", e);

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -79,17 +79,17 @@
     -fx-text-fill: white;
 }
 
-#navbarView .list-cell:even:filled {
+#navbarView .list-cell:odd:filled {
     -fx-background-color: derive(#f7882f, 20%);
 }
 
-#navbarView .list-cell:odd:filled {
+#navbarView .list-cell:even:filled {
     -fx-background-color: derive(#f7c331, 50%);
 }
-#navbarView .list-cell:odd:filled .image-view{
+#navbarView .list-cell:even:filled .image-view{
     -fx-image:url('/images/ddl_icon.png');
 }
-#navbarView .list-cell:even:filled .image-view{
+#navbarView .list-cell:odd:filled .image-view{
     -fx-image:url('/images/task_icon.png');
     -fx-alignment:left;
 }

--- a/src/test/java/guitests/AddCommandTest.java
+++ b/src/test/java/guitests/AddCommandTest.java
@@ -17,6 +17,7 @@ public class AddCommandTest extends TaskMasterGuiTest {
 
     @Test
     public void add() {
+        commandBox.runCommand("list"); //switch to all tasks first
         // add one floatingTask
         TestTask[] currentList = td.getTypicalTasks();
         TestTask taskToAdd = td.hoon;

--- a/src/test/java/guitests/BlockCommandTest.java
+++ b/src/test/java/guitests/BlockCommandTest.java
@@ -15,6 +15,7 @@ public class BlockCommandTest extends TaskMasterGuiTest {
 
     @Test
     public void block() {
+        commandBox.runCommand("list"); //switch to all tasks first
         // block one slot
         TestTask[] currentList = td.getTypicalTasks();
         TestTask slotToBlock = td.block1;

--- a/src/test/java/guitests/ClearCommandTest.java
+++ b/src/test/java/guitests/ClearCommandTest.java
@@ -11,6 +11,7 @@ public class ClearCommandTest extends TaskMasterGuiTest {
 
     @Test
     public void clear() {
+        commandBox.runCommand("list"); //switch to all tasks first
 
         TaskOccurrence[] taskComponents = TestUtil.convertTasksToDateComponents(td.getTypicalTasks());
         //verify a non-empty list can be cleared

--- a/src/test/java/guitests/CompleteCommandTest.java
+++ b/src/test/java/guitests/CompleteCommandTest.java
@@ -16,6 +16,7 @@ public class CompleteCommandTest extends TaskMasterGuiTest {
 
     @Test
     public void complete() {
+        commandBox.runCommand("list"); //switch to all tasks first
 
         // done the first in the list
         TestTask[] currentList = td.getTypicalTasks();
@@ -23,17 +24,20 @@ public class CompleteCommandTest extends TaskMasterGuiTest {
         int targetIndex = 1;
         completed[0] = currentList[targetIndex - 1];
         assertCompleteSuccess(targetIndex, currentList);
+        currentList = TestUtil.removeTaskFromList(currentList, targetIndex);
 
         // done the last in the list
         targetIndex = currentList.length;
         completed[2] = currentList[targetIndex - 1];
         assertCompleteSuccess(targetIndex, currentList);
-
+        currentList = TestUtil.removeTaskFromList(currentList, targetIndex);
+        
         // done from the middle of the list
         targetIndex = 3;
         completed[1] = currentList[targetIndex - 1];
         assertCompleteSuccess(targetIndex, currentList);
-
+        currentList = TestUtil.removeTaskFromList(currentList, targetIndex);
+        
         // invalid index
         commandBox.runCommand("done " + currentList.length + 1);
         assertResultMessage("The task index provided is invalid");
@@ -58,7 +62,7 @@ public class CompleteCommandTest extends TaskMasterGuiTest {
      */
     private void assertCompleteSuccess(int targetIndexOneIndexed, final TestTask[] currentList) {
         TestTask taskToComplete = currentList[targetIndexOneIndexed - 1]; // -1
-        TestTask[] expectedRemainder = currentList;
+        TestTask[] expectedRemainder = TestUtil.removeTaskFromList(currentList, targetIndexOneIndexed);
 
         commandBox.runCommand("done " + targetIndexOneIndexed);
 

--- a/src/test/java/guitests/DeleteCommandTest.java
+++ b/src/test/java/guitests/DeleteCommandTest.java
@@ -16,6 +16,7 @@ public class DeleteCommandTest extends TaskMasterGuiTest {
 
     @Test
     public void delete() {
+        commandBox.runCommand("list"); //switch to all tasks first
 
         //delete the first in the list
         TestTask[] currentList = td.getTypicalTasks();

--- a/src/test/java/guitests/EditCommandTest.java
+++ b/src/test/java/guitests/EditCommandTest.java
@@ -20,6 +20,7 @@ public class EditCommandTest extends TaskMasterGuiTest {
 
     @Test
     public void edit() throws IllegalValueException {
+        commandBox.runCommand("list"); //switch to all tasks first
 
         // Fix Index first to see edit effect
         // edit deadline

--- a/src/test/java/guitests/NavbarPanelTest.java
+++ b/src/test/java/guitests/NavbarPanelTest.java
@@ -15,6 +15,7 @@ public class NavbarPanelTest extends TaskMasterGuiTest {
     private final String NAVBAR_INCOMING_DEADLINES = " Incoming Deadlines";
     private final String NAVBAR_FLOATING_TASKS = " Floating Tasks";
     private final String NAVBAR_COMPLETED = " Completed";
+    private final String NAVBAR_TODAY = " Today";
 
     @Test
     public void navigateToFloatingTasks() {
@@ -49,8 +50,15 @@ public class NavbarPanelTest extends TaskMasterGuiTest {
     @Test
     public void navigateToCompletedOnes() {
         // Navigate to completed ones
+        commandBox.runCommand("list"); //switch to all tasks first
         commandBox.runCommand("done 1");
         assertResult(NAVBAR_COMPLETED, td.trash.getLastAppendedComponent());
+    }
+    
+    @Test
+    public void navigateToToday() {
+        // Navigate to today's tasks, here should be none.
+        assertResult(NAVBAR_TODAY);
     }
 
     private void assertResult(String navigation, TaskOccurrence... expectedHits) {

--- a/src/test/java/guitests/SelectCommandTest.java
+++ b/src/test/java/guitests/SelectCommandTest.java
@@ -11,6 +11,7 @@ public class SelectCommandTest extends TaskMasterGuiTest {
 
     @Test
     public void selectTask_nonEmptyList() {
+        commandBox.runCommand("list"); //switch to all tasks first
 
         assertSelectionInvalid(20); //invalid index
         assertNoTaskSelected();

--- a/src/test/java/guitests/guihandles/NavbarPanelHandle.java
+++ b/src/test/java/guitests/guihandles/NavbarPanelHandle.java
@@ -19,8 +19,9 @@ public class NavbarPanelHandle extends GuiHandle {
     private final String NAVBAR_INCOMING_DEADLINES = " Incoming Deadlines";
     private final String NAVBAR_FLOATING_TASKS = " Floating Tasks";
     private final String NAVBAR_COMPLETED = " Completed";
+    private final String NAVBAR_TODAY = " Today";
 
-    private final ObservableList<String> navbarElement = FXCollections.observableArrayList(NAVBAR_TASKS,
+    private final ObservableList<String> navbarElement = FXCollections.observableArrayList(NAVBAR_TODAY, NAVBAR_TASKS,
             NAVBAR_DEADLINES, NAVBAR_FLOATING_TASKS, NAVBAR_INCOMING_DEADLINES, NAVBAR_COMPLETED);
 
     public static final int NOT_FOUND = -1;

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -881,12 +881,14 @@ public class LogicManagerTest {
         assertCommandBehavior("find from 19 oct 10pm to 20 oct 11am",
                 Command.getMessageForTaskListShownSummary(expectedList.size()), expectedTM, expectedComponentList);
         // find by smaller boundary lists nothing
-//        assertCommandBehavior("find from 19 oct 10.01pm to 20 oct 11am", Command.getMessageForTaskListShownSummary(1),
-//                expectedTM, expectedComponentList);
+        expectedComponentList.remove(0);
+        assertCommandBehavior("find from 19 oct 10.01pm to 20 oct 11am", Command.getMessageForTaskListShownSummary(1),
+                expectedTM, expectedComponentList);
 
         assertCommandBehavior("find from 19 oct 10pm to 20 oct 10.59am", Command.getMessageForTaskListShownSummary(0),
                 expectedTM, new TaskMaster().getTaskComponentList());
         // find by lax boundary successful
+        expectedComponentList.add(0, test.getLastAppendedComponent());
         assertCommandBehavior("find from 19 oct 9pm to 20 oct 1pm",
                 Command.getMessageForTaskListShownSummary(expectedList.size()), expectedTM, expectedComponentList);
     }


### PR DESCRIPTION
I delete the showTaskToday function in model manager because it will affect the display of the agenda as they both rely on the `filteredList`, which should be all tasks.
I modify it in mainwindow so during ui initialization it will switch to that tab.
I dont think tie the list and the agenda together (through the view command) is a good idea. Because you will see only part of the tasks in the list, and the auto-added recurring tasks only on the agenda.
I'd rather list the deadlines in the tasklist though, so that would be a better combination?